### PR TITLE
feat: make it possible to be run via packageRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,17 @@ WARNING: This module has both false positives and false negatives.
 It is not meant as a full checker, but it detects basic cases.
 
 ## Install
-```
+```sh
 npm i safe-regex2
+```
+
+## Usage via npx
+
+You can use this module via `npx` without installing it globally:
+
+Example:
+```sh
+npx safe-regex2 '(x+x+)+y'
 ```
 
 ## Example

--- a/bin/safe-regex2.js
+++ b/bin/safe-regex2.js
@@ -50,12 +50,9 @@ if (options.help) {
     if (isSafe === false) {
       console.error('Provided regex is invalid or unsafe.')
       process.exit(1)
-    } else if (isSafe === true) {
+    } else {
       console.log('Provided regex is safe.')
       process.exit(0)
-    } else {
-      console.error('An unexpected error occurred while checking the regex.')
-      process.exit(1)
     }
   }
 }

--- a/bin/safe-regex2.js
+++ b/bin/safe-regex2.js
@@ -1,14 +1,10 @@
 #!/usr/bin/env node
 'use strict'
 
-const { resolve } = require('node:path')
-const { readFileSync } = require('node:fs')
 const { parseArgs } = require('node:util')
 const { safeRegex } = require('../index.js')
 
-const { version } = JSON.parse(
-  readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8')
-)
+const { version } = require('../package.json')
 
 const { values: options, positionals } = parseArgs({
   allowPositionals: true,

--- a/bin/safe-regex2.js
+++ b/bin/safe-regex2.js
@@ -27,14 +27,14 @@ const { values: options, positionals } = parseArgs({
 })
 
 function help () {
-  console.log(`Usage: safe-regex2 [options] [<regex>]
+  console.log(`Usage: safe-regex2 [options] <regex>
 
 Check if a regular expression is safe to use in a production environment.
 
 Options:
   -v, --version          Display the version number
   -h, --help             Display this help message
-  <regex>                The regular expression to check (default: stdin)`
+  <regex>                The regular expression to check`
   )
 }
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,12 @@
 const parse = require('ret')
 const types = parse.types
 
+/**
+ * @param {string|RegExp} re - The regular expression to check, can be a string or RegExp object
+ * @param {object} [opts]
+ * @param {number} [opts.limit=25] - The maximum number of repetitions allowed
+ * @returns {boolean}
+ */
 function safeRegex (re, opts) {
   if (!opts) opts = {}
   /* c8 ignore next */
@@ -46,7 +52,7 @@ function safeRegex (re, opts) {
 }
 
 function isRegExp (x) {
-  return {}.toString.call(x) === '[object RegExp]'
+  return Object.prototype.toString.call(x) === '[object RegExp]'
 }
 
 module.exports = safeRegex

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "index.js",
   "type": "commonjs",
   "types": "types/index.d.ts",
+  "bin": {
+    "safe-regex2": "bin/safe-regex2.js"
+  },
   "dependencies": {
     "ret": "~0.5.0"
   },


### PR DESCRIPTION
It is so annoying, that runkit is dead. I usually used runkit to check if a regex is kind of safe. 

So I just thought, why cant i do simply `npx safe-regex2 '^(a?){25}(a){25}$'`? 

Well this PR provides this feature.